### PR TITLE
feat: cluster initializer to directly load client.Object into the cluster

### DIFF
--- a/dev/cluster_init.go
+++ b/dev/cluster_init.go
@@ -34,7 +34,7 @@ func (l ClusterLoadObjectsFromHttp) Init(
 	return cluster.CreateAndWaitFromHttp(ctx, l)
 }
 
-// Load objects from the given client.Object and applies them into the cluster.
+// Creates the referenced Object and waits for it to be ready.
 type ClusterLoadObjectFromClientObject struct {
 	client.Object
 }

--- a/dev/cluster_init.go
+++ b/dev/cluster_init.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Load objects from given folder paths and applies them into the cluster.
@@ -31,6 +32,16 @@ type ClusterLoadObjectsFromHttp []string
 func (l ClusterLoadObjectsFromHttp) Init(
 	ctx context.Context, cluster *Cluster) error {
 	return cluster.CreateAndWaitFromHttp(ctx, l)
+}
+
+// Load objects from the given client.Object and applies them into the cluster.
+type ClusterLoadObjectFromClientObject struct {
+	client.Object
+}
+
+func (l ClusterLoadObjectFromClientObject) Init(
+	ctx context.Context, cluster *Cluster) error {
+	return cluster.CreateAndWaitForReadiness(ctx, l.Object)
 }
 
 // Adds the helm repository, updates repository cache and installs a helm package.


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

For the situations when you want to load a templatised object, rendered programmatically as client.object in runtime, to the devCluster as a cluster initializer