### PR TITLE
Add helper to add pass functions as cluster initalizer.

### DIFF
--- a/dev/cluster_init.go
+++ b/dev/cluster_init.go
@@ -10,6 +10,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Run a function with access to the cluster object. Can be used to directly interact with the cluster.
+type ClusterInitFn func(ctx context.Context, cluster *Cluster) error
+
+func (fn ClusterInitFn) Init(ctx context.Context, cl *Cluster) error {
+	return fn(ctx, cl)
+}
+
 // Load objects from given folder paths and applies them into the cluster.
 type ClusterLoadObjectsFromFolders []string
 


### PR DESCRIPTION
This helps consumers accessing the api client in the cluster object to do custom things like updating the status of an object.

Example:

```golang
dev.WithClusterInitializers(
	dev.ClusterInitFn(func(ctx context.Context, cluster *dev.Cluster) error {
		c := cluster.CtrlClient

		proxy := &shiftconfigv1.Proxy{
			ObjectMeta: &metav1.ObjectMeta{
				Name: "cluster"
			}
		}
		if err := c.Create(ctx, proxy); err != nil {
			return err
		}
		proxy.Status = shiftconfigv1.ProxyStatus{
			HTTPProxy:  "http://proxy.default.svc.cluster.local:8080",
			HTTPSProxy: "http://proxy.default.svc.cluster.local:8080",
			NoProxy:    ".cluster.local,.svc,10.244.0.0/16,10.96.0.0/16,127.0.0.1,localhost",
		}
		fmt.Println("updating proxy/cluster status")
		return c.Status().Update(ctx, proxy)
	}),
	/* other initializers.... */
)
```